### PR TITLE
add dependency updates plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ buildscript {
     }
 }
 
+plugins {
+    id "com.github.ben-manes.versions" version "0.20.0"
+}
+
 group 'com.github.qwazer'
 version "$VERSION"
 description 'A plugin for publishing markdown or confluence wiki files to to an Atlassian Confluence server'


### PR DESCRIPTION
Goal: have easy option to track outdated dependencies

To fix that, dependency updates plugin was added. Please note, that the latest version doesn't work with current version of gradle, so it would be better to update it too.

Example output is below.

```
> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - org.pegdown:pegdown:1.6.0

The following dependencies have later milestone versions:
 - com.fasterxml.jackson.core:jackson-databind [2.12.3 -> 2.14.1]
     https://github.com/FasterXML/jackson
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.20.0 -> 0.44.0]
 - com.gradle.publish:plugin-publish-plugin [0.12.0 -> 1.1.0]
 - com.jayway.jsonpath:json-path [2.4.0 -> 2.7.0]
     https://github.com/jayway/JsonPath
 - com.jfrog.bintray.gradle:gradle-bintray-plugin [1.8.4 -> 1.8.5]
 - commons-io:commons-io [2.6 -> 2.11.0]
     https://commons.apache.org/proper/commons-io/
 - junit:junit [4.12 -> 4.13.2]
     http://junit.org
 - org.jsoup:jsoup [1.11.2 -> 1.15.3]
     https://jsoup.org/
 - org.mockito:mockito-core [2.18.0 -> 4.11.0]
     https://github.com/mockito/mockito
 - org.slf4j:slf4j-api [1.7.25 -> 2.0.6]
     http://www.slf4j.org
 - org.springframework:spring-context [5.1.8.RELEASE -> 6.0.4]
     https://github.com/spring-projects/spring-framework
 - org.springframework:spring-core [5.1.8.RELEASE -> 6.0.4]
     https://github.com/spring-projects/spring-framework
 - org.springframework:spring-test [5.1.8.RELEASE -> 6.0.4]
     https://github.com/spring-projects/spring-framework
 - org.springframework:spring-web [5.1.8.RELEASE -> 6.0.4]
     https://github.com/spring-projects/spring-framework

Gradle updates:
 - Gradle: [4.8.1 -> 7.6 -> 8.0-rc-1]

Generated report file C:\git\markdown-confluence-gradle-plugin\build/dependencyUpdates\report.txt

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.8.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 5s
1 actionable task: 1 executed
22:00:53: Execution finished 'dependencyUpdates'.

```