### PR TITLE
update gradle to the latest backward-compatible version.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Mon May 25 21:24:42 BST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Note, that Gradle 7 isn't supported, because of:

* https://discuss.gradle.org/t/plugin-with-id-maven-not-found/39621
* https://stackoverflow.com/questions/23796404/could-not-find-method-compile-for-arguments-gradle