### PR TITLE
decom java older than 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.gradle.plugin-publish'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Decommission Java 1.7. Main reason: new Gradle don't support it. Moreover, new Spring doesn't support java older than Java 17.

Evidence: https://docs.gradle.org/current/userguide/compatibility.html
> A Java version between 8 and 19 is required to execute Gradle. Java 20 and later versions are not yet supported.