### PR TITLE
update build.gradle to stop using old API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -20,7 +20,6 @@ version "$VERSION"
 description 'A plugin for publishing markdown or confluence wiki files to to an Atlassian Confluence server'
 
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.gradle.plugin-publish'
@@ -33,22 +32,22 @@ repositories {
 
 
 dependencies {
-    compile gradleApi()
-    compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.springframework:spring-core:$SPRING_VERSION"
-    compile "org.springframework:spring-context:$SPRING_VERSION"
-    compile "org.springframework:spring-web:$SPRING_VERSION"
-    compile "com.jayway.jsonpath:json-path:2.4.0"
-    compile "com.fasterxml.jackson.core:jackson-databind:2.12.3"
-    compile "org.jsoup:jsoup:1.11.2"
-    compile "org.pegdown:pegdown:1.6.0"
+    implementation gradleApi()
+    implementation "org.slf4j:slf4j-api:1.7.25"
+    implementation "org.springframework:spring-core:$SPRING_VERSION"
+    implementation "org.springframework:spring-context:$SPRING_VERSION"
+    implementation "org.springframework:spring-web:$SPRING_VERSION"
+    implementation "com.jayway.jsonpath:json-path:2.4.0"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
+    implementation "org.jsoup:jsoup:1.11.2"
+    implementation "org.pegdown:pegdown:1.6.0"
 
 
-    testCompile gradleTestKit()
-    testCompile "commons-io:commons-io:2.6"
-    testCompile "junit:junit:4.12"
-    testCompile "org.mockito:mockito-core:2.18.0"
-    testCompile "org.springframework:spring-test:$SPRING_VERSION"
+    testImplementation gradleTestKit()
+    testImplementation "commons-io:commons-io:2.6"
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.mockito:mockito-core:2.18.0"
+    testImplementation "org.springframework:spring-test:$SPRING_VERSION"
 }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Mon May 25 21:24:42 BST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I found three usages of old Gradle API:
* `maven` plugin is deprecated
* `jcenter` is deprecated
* `compile`/`testCompile` are deprecated

No any gradle-related issues are exists for now (checked locally with `--warning-mode all` option):

```
19:28:29: Executing 'build --warning-mode all'...

Starting Gradle Daemon...
Gradle Daemon started in 1 s 200 ms

> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :processResources UP-TO-DATE
> Task :classes
> Task :jar
> Task :publishPluginJar UP-TO-DATE
> Task :javadoc
> Task :publishPluginJavaDocsJar
> Task :assemble

> Task :compileTestJava

> Task :processTestResources UP-TO-DATE
> Task :testClasses
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: C:\git\markdown-confluence-gradle-plugin\src\test\java\com\github\qwazer\markdown\confluence\core\service\ConfluenceServiceTestWithMocks.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
> Task :test
> Task :check
> Task :build

BUILD SUCCESSFUL in 16s
9 actionable tasks: 6 executed, 3 up-to-date
19:28:48: Execution finished 'build --warning-mode all'.

```